### PR TITLE
Switch nglview to conda-forge and removes bioconda

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ Default conda channel:
 
 * [`MDAnalysis`](https://www.mdanalysis.org/)
 * [`jupyterlab`](https://jupyterlab.readthedocs.io/en/stable/)
-
-[bioconda](http://bioconda.github.io/) channel:
-
 * [`nglview`](http://nglviewer.org/nglview/latest/)
 
 #### Known Bugs
@@ -63,3 +60,4 @@ Default conda channel:
 * Naushad Velgy
 * William Glass
 * Irfan Alibay
+* Rocco Meli

--- a/conda.yml
+++ b/conda.yml
@@ -3,7 +3,6 @@ name: WTcourse
 channels:
   - default
   - conda-forge
-  - bioconda
 
 dependencies:
   # Base


### PR DESCRIPTION
As per #25, nglview is installed via conda-forge not bioconda (I'm going to claim responsibility for this, since I added nglview to the tutorial last year).

I also added @RMeli to the authors list since he forgot to do so in #21 