### PR TITLE
Add vim swap files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 .vscode
 .idea
 *~
+.swp
 
 # os
 .DS_Store


### PR DESCRIPTION
The latest merged pull request left .swp files so just adding this to gitignore.
We can clean the homology modelling stuff later.